### PR TITLE
fix(pancake): broken link

### DIFF
--- a/aptos/pancake-swap/dashboard-zgvs3pm6.json
+++ b/aptos/pancake-swap/dashboard-zgvs3pm6.json
@@ -512,7 +512,7 @@
       "chart": {
         "datasourceType": "NOTES",
         "note": {
-          "content": "# Real-time Monitoring and Logging For Pancake Swap (Aptos)\n[Click link to check out the corresponding Github code](https://github.com/sentioxyz/sentio-processors/tree/main/projects/pancake-swap)",
+          "content": "# Real-time Monitoring and Logging For Pancake Swap (Aptos)\n[Click link to check out the corresponding GitHub code]( https://github.com/sentioxyz/sentio-processors/tree/main/aptos/pancake-swap)",
           "textAlign": "CENTER"
         },
         "type": "NOTE"


### PR DESCRIPTION
Update the new GitHub repository link for the PancakeSwap project.

Will it be updated automatically online after this PR merged? @zfy0701 